### PR TITLE
Fix mag calculation bug and optimize

### DIFF
--- a/CPU_QuickMag.sh
+++ b/CPU_QuickMag.sh
@@ -1,30 +1,30 @@
 #! /bin/bash
 
 
-## CPU_QuickMag 
-# 
-# You must run $bash UpdateDatabaseFiles.sh before running this program to download the necessary data. 
-# 
+## CPU_QuickMag
+#
+# You must run $bash UpdateDatabaseFiles.sh before running this program to download the necessary data.
+#
 #
 # bash CPU_QuickMag.sh [CPUid] [#hosts] [output]
-# 
+#
 # [CPUid]	:	CPU id string e.g. 'i7-6700 ' (check CPUlist.data for more examples)
 # [#hosts]	:	number of hosts to return data for
 # [output]	:	save output to file name (optional)
 #
 # Requires: python and math package
-# 
+#
 # @author nexus-prime
 # @version 1.0.3
 
 # Check for help flag
 if [ "$1" == "--help" ] || [ "$1" == "-h" ]; then
-  echo "Usage: `basename $0` 
+  echo "Usage: `basename $0`
 
-# You must run 'bash UpdateDatabaseFiles.sh' before running this program to download the necessary data. 
+# You must run 'bash UpdateDatabaseFiles.sh' before running this program to download the necessary data.
 #
 # bash CPU_QuickMag.sh [CPUid] [#hosts] [output]
-# 
+#
 # [CPUid]	:	CPU id string e.g. 'i7-6700 ' (check CPUlist.data for more examples)
 # [#hosts]	:	number of hosts to return data for
 # [output]	:	save output to file name (optional)
@@ -33,7 +33,6 @@ if [ "$1" == "--help" ] || [ "$1" == "-h" ]; then
  "
   exit 0
 fi
-
 
 
 
@@ -50,6 +49,16 @@ fi
 # Rename Inputs
 CPUid=$1
 iters=$2
+
+# Make CPUid uppercase to match the case of the host files
+CPUid=$(echo -n "$CPUid" | awk '{ print toupper($0)}')
+
+# Use ripgrep if it is on the system
+if which rg 2>&1 > /dev/null ; then
+  grepcmd=rg
+else
+  grepcmd=grep
+fi
 
 mypath="$( cd "$(dirname "$0")" ; pwd -P)"
 
@@ -69,30 +78,30 @@ declare -a iterationSF=( "0 1 2 3 4 5 6 7 8 9 10 11 12 13" ) #( "0 1 2 3 4 5 6 7
 ProjWithStandForm=( odlk1 srbase yafu tngrid vgtu numf nfs universe csg cosmology lhc rosetta  yoyo wcg )
 
 ## Get Top Rac for CPU model
-odlk1=$(cat $mypath/HostFiles/CtODLK1hosts 2>/dev/null | grep -i -A 4 "$CPUid"|  grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters ) 
-srbase=$(cat $mypath/HostFiles/CtSRBASEhosts 2>/dev/null | grep -i -A 4 "$CPUid"|  grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters ) 
-yafu=$(cat $mypath/HostFiles/CtYAFUhosts 2>/dev/null | grep -i -A 4 "$CPUid"|  grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters ) 
-tngrid=$(cat $mypath/HostFiles/CtTNGRIDhosts 2>/dev/null | grep -i -A 4 "$CPUid"|  grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters ) 
-vgtu=$(cat $mypath/HostFiles/CtVGTUhosts 2>/dev/null | grep -i -A 4 "$CPUid"|  grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters ) 
-#DD=$(cat $mypath/HostFiles/CtDDhosts 2>/dev/null | grep -i -A 4 "$CPUid"|  grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters ) # Removed from Whitelist
-numf=$(cat $mypath/HostFiles/CtNUMFhosts 2>/dev/null | grep -i -A 4 "$CPUid"|  grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters ) 
-nfs=$(cat $mypath/HostFiles/CtNFShosts 2>/dev/null | grep -i -A 4 "$CPUid"|  grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters ) 
-universe=$(cat $mypath/HostFiles/CtUNIVERSEhosts 2>/dev/null | grep -i -A 4 "$CPUid"|  grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters ) 
-csg=$(cat $mypath/HostFiles/CtCSGhosts 2>/dev/null | grep -i -A 4 "$CPUid"|  grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters ) 
-cosmology=$(cat $mypath/HostFiles/CtCOSMOLOGYhosts 2>/dev/null |grep -i -A 4 "$CPUid"|  grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters ) 
-lhc=$(cat $mypath/HostFiles/CtLHChosts 2>/dev/null |grep -i -A 4 "$CPUid"|  grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters ) 
-rosetta=$(cat $mypath/HostFiles/CtROSETTAhosts 2>/dev/null | grep -i -A 4 "$CPUid"|  grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters ) 
-yoyo=$(cat $mypath/HostFiles/CtYOYOhosts 2>/dev/null | grep -i -A 4 "$CPUid"|  grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters ) 
-wcg=$(cat $mypath/HostFiles/CtWCGhosts 2>/dev/null | grep -i -A 4 "$CPUid"|  grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters )  # Temporary Issues with GDPR compliance
+odlk1=$(cat $mypath/HostFiles/CtODLK1hosts 2>/dev/null | $grepcmd -F "$CPUid" | awk '{print $1}' | grep -Eo "[0-9]+\.[0-9]+" | sort -rn | head -n $iters )
+srbase=$(cat $mypath/HostFiles/CtSRBASEhosts 2>/dev/null | $grepcmd -F "$CPUid" | awk '{print $1}' | grep -Eo "[0-9]+\.[0-9]+" | sort -rn | head -n $iters )
+yafu=$(cat $mypath/HostFiles/CtYAFUhosts 2>/dev/null | $grepcmd -F "$CPUid" | awk '{print $1}' | grep -Eo "[0-9]+\.[0-9]+" | sort -rn | head -n $iters )
+tngrid=$(cat $mypath/HostFiles/CtTNGRIDhosts 2>/dev/null | $grepcmd -F "$CPUid" | awk '{print $1}' | grep -Eo "[0-9]+\.[0-9]+" | sort -rn | head -n $iters )
+vgtu=$(cat $mypath/HostFiles/CtVGTUhosts 2>/dev/null | $grepcmd -F "$CPUid" | awk '{print $1}' | grep -Eo "[0-9]+\.[0-9]+" | sort -rn | head -n $iters )
+#DD=$(cat $mypath/HostFiles/CtDDhosts 2>/dev/null | $grepcmd -F "$CPUid" | awk '{print $1}' | grep -Eo "[0-9]+\.[0-9]+" | sort -rn | head -n $iters ) # Removed from Whitelist
+numf=$(cat $mypath/HostFiles/CtNUMFhosts 2>/dev/null | $grepcmd -F "$CPUid" | awk '{print $1}' | grep -Eo "[0-9]+\.[0-9]+" | sort -rn | head -n $iters )
+nfs=$(cat $mypath/HostFiles/CtNFShosts 2>/dev/null | $grepcmd -F "$CPUid" | awk '{print $1}' | grep -Eo "[0-9]+\.[0-9]+" | sort -rn | head -n $iters )
+universe=$(cat $mypath/HostFiles/CtUNIVERSEhosts 2>/dev/null | $grepcmd -F "$CPUid" | awk '{print $1}' | grep -Eo "[0-9]+\.[0-9]+" | sort -rn | head -n $iters )
+csg=$(cat $mypath/HostFiles/CtCSGhosts 2>/dev/null | $grepcmd -F "$CPUid" | awk '{print $1}' | grep -Eo "[0-9]+\.[0-9]+" | sort -rn | head -n $iters )
+cosmology=$(cat $mypath/HostFiles/CtCOSMOLOGYhosts 2>/dev/null | $grepcmd -F "$CPUid" | awk '{print $1}' | grep -Eo "[0-9]+\.[0-9]+" | sort -rn | head -n $iters )
+lhc=$(cat $mypath/HostFiles/CtLHChosts 2>/dev/null | $grepcmd -F "$CPUid" | awk '{print $1}' | grep -Eo "[0-9]+\.[0-9]+" | sort -rn | head -n $iters )
+rosetta=$(cat $mypath/HostFiles/CtROSETTAhosts 2>/dev/null | $grepcmd -F "$CPUid" | awk '{print $1}' | grep -Eo "[0-9]+\.[0-9]+" | sort -rn | head -n $iters )
+yoyo=$(cat $mypath/HostFiles/CtYOYOhosts 2>/dev/null | $grepcmd -F "$CPUid" | awk '{print $1}' | grep -Eo "[0-9]+\.[0-9]+" | sort -rn | head -n $iters )
+wcg=$(cat $mypath/HostFiles/CtWCGhosts 2>/dev/null | $grepcmd -F "$CPUid" | awk '{print $1}' | grep -Eo "[0-9]+\.[0-9]+" | sort -rn | head -n $iters ) # Temporary Issues with GDPR compliance
 
 
 #Check for missing data
 for project in $iterationSF
 do
 	eval CurrentProj='${'${ProjWithStandForm[$project]}'[@]}'
-	
+
 	if [ -z "$CurrentProj" ]; then
-		
+
 		eval "${ProjWithStandForm[$project]}"='$(for i in {1..'$iters'}; do echo -n '"'"'0 '"'"'; done)'
 		echo "Missing Host Data: ${ProjWithStandForm[$project]}"
 	fi
@@ -117,32 +126,32 @@ cosmology=($cosmology)
 lhc=($lhc)
 rosetta=($rosetta)
 yoyo=($yoyo)
-wcg=($wcg) 
+wcg=($wcg)
 
 
 # Find gridcoin team RAC
-TModlk1="$(cat $mypath/TeamFiles/ODLK1team 2>/dev/null | grep -B 4 -A 3 ">Gridcoin<" | grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+")"
-TMsrbase="$(cat $mypath/TeamFiles/SRBASEteam 2>/dev/null | grep -B 4 -A 3 ">Gridcoin<" | grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+")"
-TMyafu="$(cat $mypath/TeamFiles/YAFUteam 2>/dev/null | grep -B 4 -A 3 ">Gridcoin<" | grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+")"
-TMtngrid="$(cat $mypath/TeamFiles/TNGRIDteam 2>/dev/null | grep -B 4 -A 3 ">Gridcoin<" | grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+")"
-TMvgtu="$(cat $mypath/TeamFiles/VGTUteam 2>/dev/null | grep -B 4 -A 3 ">Gridcoin<" | grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+")"
-#TMDD="$(cat $mypath/TeamFiles/DDteam 2>/dev/null | grep -B 4 -A 3 ">Gridcoin<" | grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+")" # Removed from Whitelist
-TMnumf="$(cat $mypath/TeamFiles/NUMFteam 2>/dev/null | grep -B 4 -A 3 ">Gridcoin<" | grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+")"
-TMnfs="$(cat $mypath/TeamFiles/NFSteam 2>/dev/null | grep -B 4 -A 3 ">Gridcoin<" | grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+")"
-TMuniverse="$(cat $mypath/TeamFiles/UNIVERSEteam 2>/dev/null | grep -B 4 -A 3 ">Gridcoin<" | grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+")"
-TMcsg="$(cat $mypath/TeamFiles/CSGteam 2>/dev/null | grep -B 4 -A 3 ">Gridcoin<" | grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+")"
-TMcosmology="$(cat $mypath/TeamFiles/COSMOLOGYteam 2>/dev/null | grep -B 4 -A 3 ">Gridcoin<" | grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+")"
-TMlhc="$(cat $mypath/TeamFiles/LHCteam 2>/dev/null | grep -B 4 -A 3 ">Gridcoin<" | grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+")"
-TMrosetta="$(cat $mypath/TeamFiles/ROSETTAteam 2>/dev/null | grep -B 4 -A 3 ">Gridcoin<" | grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+")"
-TMyoyo="$(cat $mypath/TeamFiles/YOYOteam 2>/dev/null | grep -B 4 -A 3 ">Gridcoin<" | grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+")"
-TMwcg="$(cat $mypath/TeamFiles/WCGteam 2>/dev/null | grep -B 4 -A 3 ">Gridcoin<" | grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+")"  # Temporary Issues with GDPR compliance
+TModlk1="$(cat $mypath/TeamFiles/ODLK1team 2>/dev/null | grep -A 3 "<name>Gridcoin</name>" | grep "<expavg_credit>"|grep -Eo "[0-9]+\.[0-9]+")"
+TMsrbase="$(cat $mypath/TeamFiles/SRBASEteam 2>/dev/null | grep -A 3 "<name>Gridcoin</name>" | grep "<expavg_credit>"|grep -Eo "[0-9]+\.[0-9]+")"
+TMyafu="$(cat $mypath/TeamFiles/YAFUteam 2>/dev/null | grep -A 3 "<name>Gridcoin</name>" | grep "<expavg_credit>"|grep -Eo "[0-9]+\.[0-9]+")"
+TMtngrid="$(cat $mypath/TeamFiles/TNGRIDteam 2>/dev/null | grep -A 3 "<name>Gridcoin</name>" | grep "<expavg_credit>"|grep -Eo "[0-9]+\.[0-9]+")"
+TMvgtu="$(cat $mypath/TeamFiles/VGTUteam 2>/dev/null | grep -A 3 "<name>Gridcoin</name>" | grep "<expavg_credit>"|grep -Eo "[0-9]+\.[0-9]+")"
+#TMDD="$(cat $mypath/TeamFiles/DDteam 2>/dev/null | grep -A 3 "<name>Gridcoin</name>" | grep "<expavg_credit>"|grep -Eo "[0-9]+\.[0-9]+")" # Removed from Whitelist
+TMnumf="$(cat $mypath/TeamFiles/NUMFteam 2>/dev/null | grep -A 3 "<name>Gridcoin</name>" | grep "<expavg_credit>"|grep -Eo "[0-9]+\.[0-9]+")"
+TMnfs="$(cat $mypath/TeamFiles/NFSteam 2>/dev/null | grep -A 3 "<name>Gridcoin</name>" | grep "<expavg_credit>"|grep -Eo "[0-9]+\.[0-9]+")"
+TMuniverse="$(cat $mypath/TeamFiles/UNIVERSEteam 2>/dev/null | grep -A 3 "<name>Gridcoin</name>" | grep "<expavg_credit>"|grep -Eo "[0-9]+\.[0-9]+")"
+TMcsg="$(cat $mypath/TeamFiles/CSGteam 2>/dev/null | grep -A 3 "<name>Gridcoin</name>" | grep "<expavg_credit>"|grep -Eo "[0-9]+\.[0-9]+")"
+TMcosmology="$(cat $mypath/TeamFiles/COSMOLOGYteam 2>/dev/null | grep -A 3 "<name>Gridcoin</name>" | grep "<expavg_credit>"|grep -Eo "[0-9]+\.[0-9]+")"
+TMlhc="$(cat $mypath/TeamFiles/LHCteam 2>/dev/null | grep -A 3 "<name>Gridcoin</name>" | grep "<expavg_credit>"|grep -Eo "[0-9]+\.[0-9]+")"
+TMrosetta="$(cat $mypath/TeamFiles/ROSETTAteam 2>/dev/null | grep -A 3 "<name>Gridcoin</name>" | grep "<expavg_credit>"|grep -Eo "[0-9]+\.[0-9]+")"
+TMyoyo="$(cat $mypath/TeamFiles/YOYOteam 2>/dev/null | grep -A 3 "<name>Gridcoin</name>" | grep "<expavg_credit>"|grep -Eo "[0-9]+\.[0-9]+")"
+TMwcg="$(cat $mypath/TeamFiles/WCGteam 2>/dev/null | grep -A 3 "<name>Gridcoin</name>" | grep "<expavg_credit>"|grep -Eo "[0-9]+\.[0-9]+")"  # Temporary Issues with GDPR compliance
 
 
 # Check for missing data
 for project in $iterationSF
 do
 	eval CurrentProj='${'TM${ProjWithStandForm[$project]}'[@]}'
-	
+
 	if [ -z "$CurrentProj" ]; then
 		eval "TM${ProjWithStandForm[$project]}"=9999999999999999 #Set unknown TeamRac to large number
 		echo "Missing Team Data: ${ProjWithStandForm[$project]}"
@@ -161,7 +170,7 @@ TeamRac=($TeamRac)
 
 
 # Insert table header
-echo "Project  |  Top $iters magnitude(s) for $CPUid" > $StatsOut
+echo "Project  |  Top $iters magnitude(s) for $1" > $StatsOut
 
 
 
@@ -172,31 +181,31 @@ do
 
 	MagMult=$(python -c "print (1 * 115000 / $NumWL / float(${TeamRac[$project]}))") # Calculate magnitude multiplier for the project
 	eval ProjData='${'${ProjWithStandForm[$project]}'[@]}'
-	
+
 	ProjData=(${ProjData[@]})
-	
+
 	locMag=''
 		for jnd in `seq 0 $(($iters-1))`;
 		do
 			locMag[$jnd]=0.00
-			
+
 			if [[ ${ProjData[$jnd]+abc} ]]; then
 				locMag[$jnd]=$(python -c "print(${ProjData[$jnd]}*$MagMult)") 		# Set local magnitude if host RAC data is present
 			fi
-			
+
 		done
 
 	printf "${ProjWithStandForm[$project]}" >> $StatsOut 							# Add project name to table
 	LC_NUMERIC="en_US.UTF-8" printf " %0.2f" "${locMag[@]}" >> $StatsOut  			# Print host Mag with 2 decimals
-	printf "\n"  >> $StatsOut 
+	printf "\n"  >> $StatsOut
 
-	unset ProjData	
+	unset ProjData
 	unset locMag
 done
 
 # Print out table if no save location given
 if [ $# -eq 2 ]; then
 	head -n 1 $mypath/return.temp
-	tail -n +2 $mypath/return.temp | column -t -s' ' 
+	tail -n +2 $mypath/return.temp | column -t -s' '
 	rm $mypath/return.temp
 fi

--- a/GPU_QuickMag.sh
+++ b/GPU_QuickMag.sh
@@ -1,30 +1,30 @@
 #! /bin/bash
 
 
-## GPU_QuickMag 
-# 
-# You must run $bash UpdateDatabaseFiles.sh before running this program to download the necessary data. 
-# 
+## GPU_QuickMag
+#
+# You must run $bash UpdateDatabaseFiles.sh before running this program to download the necessary data.
+#
 #
 # bash GPU_QuickMag.sh [GPUid] [#hosts] [output]
-# 
+#
 # [GPUid]	:	GPU id string e.g. 'GTX 1080 Ti|1|' (check GPUlist.data for more examples)
 # [#hosts]	:	number of hosts to return data for
 # [output]	:	save output to file name (optional)
 #
 # Requires: python
-# 
+#
 # @author nexus-prime
 # @version 1.0.2
 
 # Check for help flag
 if [ "$1" == "--help" ] || [ "$1" == "-h" ]; then
-  echo "Usage: `basename $0` 
+  echo "Usage: `basename $0`
 
-# You must run 'bash UpdateDatabaseFiles.sh' before running this program to download the necessary data. 
+# You must run 'bash UpdateDatabaseFiles.sh' before running this program to download the necessary data.
 #
 # bash GPU_QuickMag.sh [GPUid] [#hosts] [output]
-# 
+#
 # [GPUid]	:	GPU id string e.g. 'GTX 1080 Ti|1|' (check GPUlist.data for more examples)
 # [#hosts]	:	number of hosts to return data for
 # [output]	:	save output to file name (optional)
@@ -48,7 +48,19 @@ fi
 # Rename Inputs
 GPUid=$1
 iters=$2
+
+# Make GPUid uppercase to match the case of the host files
+GPUid=$(echo -n "$GPUid" | awk '{ print toupper($0)}')
+
 mypath="$( cd "$(dirname "$0")" ; pwd -P)"
+
+# Use ripgrep if it is on the system
+if which rg 2>&1 > /dev/null ; then
+  grepcmd=rg
+else
+  grepcmd=grep
+fi
+
 # Print to terminal?
 if [ $# -eq 2 ]; then
 	StatsOut=$mypath/return.temp
@@ -63,44 +75,40 @@ NumWL=$(wget -q -O- https://www.gridcoinstats.eu/project/ | grep 'Included Proje
 declare -a iterationSF=( "0 1 2 3 4 5 6 7 8" )
 ProjWithStandForm=( amicable collatz enigma pgrid einstein milkyway seti gpug asteroids )
 
-
-
 ## Get Top Rac for GPU model
 
 nVidSearch=$( echo $GPUid | grep -iE "(GT|Quadro|NVS|TITAN|GeForce|Tesla|RTX)" )
 
-
 if [ -n "$nVidSearch" ]; then
-	
-	amicable=$(cat $mypath/HostFiles/GtAMICABLEhosts | grep -i -A 4 "$GPUid" | sed -n '/CUDA*CUDA/!p;: m;//{$!{n;b m};}'| sed -n '/CAL/!p;: m;//{$!{n;b m};}'| grep -i -A 4 "$GPUid" | grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters) 
-	collatz=$(cat $mypath/HostFiles/GtCOLLATZhosts | grep -i -A 4 "$GPUid" | sed -n '/CUDA*CUDA/!p;: m;//{$!{n;b m};}'| sed -n '/CAL/!p;: m;//{$!{n;b m};}'| grep -i -A 4 "$GPUid"  | grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters) 
-	enigma=$(cat $mypath/HostFiles/GtENIGMAhosts | grep -i -A 4 "$GPUid" | sed -n '/CUDA*CUDA/!p;: m;//{$!{n;b m};}'| sed -n '/CAL/!p;: m;//{$!{n;b m};}'| grep -i -A 4 "$GPUid"  | grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters) 
-	pgrid=$(cat $mypath/HostFiles/GtPGRIDhosts | grep -i -A 4 "$GPUid" | sed -n '/CUDA*CUDA/!p;: m;//{$!{n;b m};}'| sed -n '/CAL/!p;: m;//{$!{n;b m};}'| grep -i -A 4 "$GPUid"  | grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters) 
-	einstein=$(cat $mypath/HostFiles/GtEINSTEINhosts | grep -i -A 4 "$GPUid" | sed -n '/CUDA*CUDA/!p;: m;//{$!{n;b m};}'| sed -n '/CAL/!p;: m;//{$!{n;b m};}'| grep -i -A 4 "$GPUid"  | grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters) 
-	milkyway=$(cat $mypath/HostFiles/GtMWhosts | grep -i -A 4 "$GPUid" | sed -n '/CUDA*CUDA/!p;: m;//{$!{n;b m};}'| sed -n '/CAL/!p;: m;//{$!{n;b m};}'| grep -i -A 4 "$GPUid"  | grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n  $iters) 
-	seti=$(cat $mypath/HostFiles/GtSETIhosts | grep -i -A 4 "$GPUid" | sed -n '/CUDA*CUDA/!p;: m;//{$!{n;b m};}'| sed -n '/CAL/!p;: m;//{$!{n;b m};}'| grep -i -A 4 "$GPUid"  | grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters) 
-	gpug=$(cat $mypath/HostFiles/GtGPUGhosts | grep -i -A 4 "$GPUid" | sed -n '/CUDA*CUDA/!p;: m;//{$!{n;b m};}'| sed -n '/CAL/!p;: m;//{$!{n;b m};}'| grep -i -A 4 "$GPUid"  | grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters) 
-	asteroids=$(cat $mypath/HostFiles/GtASTEROIDShosts 2>/dev/null | grep -i -A 4 "$GPUid" | sed -n '/CUDA*CUDA/!p;: m;//{$!{n;b m};}'| sed -n '/CAL/!p;: m;//{$!{n;b m};}'| grep -i -A 4 "$GPUid"  | grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters) 
+
+	amicable=$(cat $mypath/HostFiles/GtAMICABLEhosts | $grepcmd -F "$GPUid" | sed -n '/CUDA*CUDA/!p;: m;//{$!{n;b m};}'| sed -n '/CAL/!p;: m;//{$!{n;b m};}' | awk '{print $1}' | grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters)
+	collatz=$(cat $mypath/HostFiles/GtCOLLATZhosts | $grepcmd -F "$GPUid" | sed -n '/CUDA*CUDA/!p;: m;//{$!{n;b m};}'| sed -n '/CAL/!p;: m;//{$!{n;b m};}' | awk '{print $1}' | grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters)
+	enigma=$(cat $mypath/HostFiles/GtENIGMAhosts | $grepcmd -F "$GPUid" | sed -n '/CUDA*CUDA/!p;: m;//{$!{n;b m};}'| sed -n '/CAL/!p;: m;//{$!{n;b m};}' | awk '{print $1}' | grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters)
+	pgrid=$(cat $mypath/HostFiles/GtPGRIDhosts | $grepcmd -F "$GPUid" | sed -n '/CUDA*CUDA/!p;: m;//{$!{n;b m};}'| sed -n '/CAL/!p;: m;//{$!{n;b m};}' | awk '{print $1}' | grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters)
+	einstein=$(cat $mypath/HostFiles/GtEINSTEINhosts | $grepcmd -F "$GPUid" | sed -n '/CUDA*CUDA/!p;: m;//{$!{n;b m};}'| sed -n '/CAL/!p;: m;//{$!{n;b m};}' | awk '{print $1}' | grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters)
+	milkyway=$(cat $mypath/HostFiles/GtMWhosts | $grepcmd -F "$GPUid" | sed -n '/CUDA*CUDA/!p;: m;//{$!{n;b m};}'| sed -n '/CAL/!p;: m;//{$!{n;b m};}' | awk '{print $1}' | grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n  $iters)
+	seti=$(cat $mypath/HostFiles/GtSETIhosts | $grepcmd -F "$GPUid" | sed -n '/CUDA*CUDA/!p;: m;//{$!{n;b m};}'| sed -n '/CAL/!p;: m;//{$!{n;b m};}' | awk '{print $1}' | grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters)
+	gpug=$(cat $mypath/HostFiles/GtGPUGhosts | $grepcmd -F "$GPUid" | sed -n '/CUDA*CUDA/!p;: m;//{$!{n;b m};}'| sed -n '/CAL/!p;: m;//{$!{n;b m};}' | awk '{print $1}' | grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters)
+	asteroids=$(cat $mypath/HostFiles/GtASTEROIDShosts 2>/dev/null | $grepcmd -F "$GPUid" | sed -n '/CUDA*CUDA/!p;: m;//{$!{n;b m};}'| sed -n '/CAL/!p;: m;//{$!{n;b m};}' | awk '{print $1}' | grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters)
 else
-	
-	amicable=$(cat $mypath/HostFiles/GtAMICABLEhosts | grep -i -A 4 "$GPUid" | sed -n '/CAL*CAL/!p;: m;//{$!{n;b m};}'| sed -n '/CUDA/!p;: m;//{$!{n;b m};}'| grep -i -A 4 "$GPUid" | grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters) 
-	collatz=$(cat $mypath/HostFiles/GtCOLLATZhosts | grep -i -A 4 "$GPUid" | sed -n '/CAL*CAL/!p;: m;//{$!{n;b m};}'| sed -n '/CUDA/!p;: m;//{$!{n;b m};}'| grep -i -A 4 "$GPUid"  | grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters) 
-	enigma=$(cat $mypath/HostFiles/GtENIGMAhosts | grep -i -A 4 "$GPUid" | sed -n '/CAL*CAL/!p;: m;//{$!{n;b m};}'| sed -n '/CUDA/!p;: m;//{$!{n;b m};}'| grep -i -A 4 "$GPUid"  | grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters) 
-	pgrid=$(cat $mypath/HostFiles/GtPGRIDhosts | grep -i -A 4 "$GPUid" | sed -n '/CAL*CAL/!p;: m;//{$!{n;b m};}'| sed -n '/CUDA/!p;: m;//{$!{n;b m};}'| grep -i -A 4 "$GPUid"  | grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters) 
-	einstein=$(cat $mypath/HostFiles/GtEINSTEINhosts | grep -i -A 4 "$GPUid" | sed -n '/CAL*CAL/!p;: m;//{$!{n;b m};}'| sed -n '/CUDA/!p;: m;//{$!{n;b m};}'| grep -i -A 4 "$GPUid"  | grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters) 
-	milkyway=$(cat $mypath/HostFiles/GtMWhosts | grep -i -A 4 "$GPUid" | sed -n '/CAL*CAL/!p;: m;//{$!{n;b m};}'| sed -n '/CUDA/!p;: m;//{$!{n;b m};}'| grep -i -A 4 "$GPUid"  | grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n  $iters) 
-	seti=$(cat $mypath/HostFiles/GtSETIhosts | grep -i -A 4 "$GPUid" | sed -n '/CAL*CAL/!p;: m;//{$!{n;b m};}'| sed -n '/CUDA/!p;: m;//{$!{n;b m};}'| grep -i -A 4 "$GPUid"  | grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters) 
+
+	amicable=$(cat $mypath/HostFiles/GtAMICABLEhosts | $grepcmd -F "$GPUid" | sed -n '/CAL*CAL/!p;: m;//{$!{n;b m};}'| sed -n '/CUDA/!p;: m;//{$!{n;b m};}' | awk '{print $1}' | grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters)
+	collatz=$(cat $mypath/HostFiles/GtCOLLATZhosts | $grepcmd -F "$GPUid" | sed -n '/CAL*CAL/!p;: m;//{$!{n;b m};}'| sed -n '/CUDA/!p;: m;//{$!{n;b m};}' | awk '{print $1}' | grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters)
+	enigma=$(cat $mypath/HostFiles/GtENIGMAhosts | $grepcmd -F "$GPUid" | sed -n '/CAL*CAL/!p;: m;//{$!{n;b m};}'| sed -n '/CUDA/!p;: m;//{$!{n;b m};}' | awk '{print $1}' | grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters)
+	pgrid=$(cat $mypath/HostFiles/GtPGRIDhosts | $grepcmd -F "$GPUid" | sed -n '/CAL*CAL/!p;: m;//{$!{n;b m};}'| sed -n '/CUDA/!p;: m;//{$!{n;b m};}' | awk '{print $1}' | grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters)
+	einstein=$(cat $mypath/HostFiles/GtEINSTEINhosts | $grepcmd -F "$GPUid" | sed -n '/CAL*CAL/!p;: m;//{$!{n;b m};}'| sed -n '/CUDA/!p;: m;//{$!{n;b m};}' | awk '{print $1}' | grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters)
+	milkyway=$(cat $mypath/HostFiles/GtMWhosts | $grepcmd -F "$GPUid" | sed -n '/CAL*CAL/!p;: m;//{$!{n;b m};}'| sed -n '/CUDA/!p;: m;//{$!{n;b m};}' | awk '{print $1}' | grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n  $iters)
+	seti=$(cat $mypath/HostFiles/GtSETIhosts | $grepcmd -F "$GPUid" | sed -n '/CAL*CAL/!p;: m;//{$!{n;b m};}'| sed -n '/CUDA/!p;: m;//{$!{n;b m};}' | awk '{print $1}' | grep -Eo "[0-9]+\.[0-9]+"| sort -rn | head -n $iters)
 	eval gpug='$(for i in {1..'$iters'}; do echo -n '"'"'0 '"'"'; done)'
 fi
-
 
 #Check for missing data
 for project in $iterationSF
 do
 	eval CurrentProj='${'${ProjWithStandForm[$project]}'[@]}'
-	
+
 	if [ -z "$CurrentProj" ]; then
-		
+
 		eval "${ProjWithStandForm[$project]}"='$(for i in {1..'$iters'}; do echo -n '"'"'0 '"'"'; done)'
 		echo "Missing Host Data: ${ProjWithStandForm[$project]}"
 	fi
@@ -110,11 +118,11 @@ unset CurrentProj
 unset project
 
 # Parse string to bash list
-amicable=($amicable)   
+amicable=($amicable)
 collatz=($collatz)
 enigma=($enigma)
 pgrid=($pgrid)
-einstein=($einstein) 
+einstein=($einstein)
 milkyway=($milkyway)
 seti=($seti)
 gpug=($gpug)
@@ -122,22 +130,21 @@ asteroids=($asteroids)
 
 
 # Find gridcoin team RAC
-TMamicable="$(cat $mypath/TeamFiles/AMICABLEteam | grep -B 4 -A 3 ">Gridcoin<" | grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+")"
-TMcollatz="$(cat $mypath/TeamFiles/COLLATZteam | grep -B 4 -A 3 ">Gridcoin<" | grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+")"
-TMenigma="$(cat $mypath/TeamFiles/ENIGMAteam | grep -B 4 -A 3 ">Gridcoin<" | grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+")"
-TMpgrid="$(cat $mypath/TeamFiles/PGRIDteam | grep -B 4 -A 3 ">Gridcoin<" | grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+")"
-TMeinstein="$(cat $mypath/TeamFiles/EINSTEINteam | grep -B 4 -A 3 ">Gridcoin<" | grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+")"
-TMmilkyway="$(cat $mypath/TeamFiles/MWteam | grep -B 4 -A 3 ">Gridcoin<" | grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+")"
-TMseti="$(cat $mypath/TeamFiles/SETIteam | grep -B 4 -A 3 ">Gridcoin<" | grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+")"
-TMgpug="$(cat $mypath/TeamFiles/GPUGteam | grep -B 4 -A 3 ">Gridcoin<" | grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+")"
-TMasteroids="$(cat $mypath/TeamFiles/ASTEROIDSteam 2>/dev/null | grep -B 4 -A 3 ">Gridcoin<" | grep "expavg_credit"|grep -Eo "[0-9]+\.[0-9]+")"
-
+TMamicable="$(cat $mypath/TeamFiles/AMICABLEteam | grep -A 3 "<name>Gridcoin</name>" | grep "<expavg_credit>"|grep -Eo "[0-9]+\.[0-9]+")"
+TMcollatz="$(cat $mypath/TeamFiles/COLLATZteam | grep -A 3 "<name>Gridcoin</name>" | grep "<expavg_credit>"|grep -Eo "[0-9]+\.[0-9]+")"
+TMenigma="$(cat $mypath/TeamFiles/ENIGMAteam | grep -A 3 "<name>Gridcoin</name>" | grep "<expavg_credit>"|grep -Eo "[0-9]+\.[0-9]+")"
+TMpgrid="$(cat $mypath/TeamFiles/PGRIDteam | grep -A 3 "<name>Gridcoin</name>" | grep "<expavg_credit>"|grep -Eo "[0-9]+\.[0-9]+")"
+TMeinstein="$(cat $mypath/TeamFiles/EINSTEINteam | grep -A 3 "<name>Gridcoin</name>" | grep "<expavg_credit>"|grep -Eo "[0-9]+\.[0-9]+")"
+TMmilkyway="$(cat $mypath/TeamFiles/MWteam | grep -A 3 "<name>Gridcoin</name>" | grep "<expavg_credit>"|grep -Eo "[0-9]+\.[0-9]+")"
+TMseti="$(cat $mypath/TeamFiles/SETIteam | grep -A 3 "<name>Gridcoin</name>" | grep "<expavg_credit>"|grep -Eo "[0-9]+\.[0-9]+")"
+TMgpug="$(cat $mypath/TeamFiles/GPUGteam | grep -A 3 "<name>Gridcoin</name>" | grep "<expavg_credit>"|grep -Eo "[0-9]+\.[0-9]+")"
+TMasteroids="$(cat $mypath/TeamFiles/ASTEROIDSteam 2>/dev/null | grep -A 3 "<name>Gridcoin</name>" | grep "<expavg_credit>"|grep -Eo "[0-9]+\.[0-9]+")"
 
 # Check for missing data
 for project in $iterationSF
 do
 	eval CurrentProj='${'TM${ProjWithStandForm[$project]}'[@]}'
-	
+
 	if [ -z "$CurrentProj" ]; then
 		eval "TM${ProjWithStandForm[$project]}"=9999999999999999 #Set unknown TeamRac to large number
 		echo "Missing Team Data: ${ProjWithStandForm[$project]}"
@@ -156,9 +163,9 @@ TeamRac=($TeamRac)
 
 # Insert table header
 if [ -n "$nVidSearch" ]; then
-	echo "Project  |  Top $iters magnitude(s) for Nvidia $GPUid" > $StatsOut
+	echo "Project  |  Top $iters magnitude(s) for Nvidia $1" > $StatsOut
 else
-	echo "Project  |  Top $iters magnitude(s) for AMD $GPUid" > $StatsOut
+	echo "Project  |  Top $iters magnitude(s) for AMD $1" > $StatsOut
 fi
 
 
@@ -169,31 +176,31 @@ do
 
 	MagMult=$(python -c "print (1 * 115000 / $NumWL / float(${TeamRac[$project]}))") # Calculate magnitude multiplier for the project
 	eval ProjData='${'${ProjWithStandForm[$project]}'[@]}'
-	
+
 	ProjData=(${ProjData[@]})
-	
+
 	locMag=''
 		for jnd in `seq 0 $(($iters-1))`;
 		do
 			locMag[$jnd]=0.00
-			
+
 			if [[ ${ProjData[$jnd]+abc} ]]; then
 				locMag[$jnd]=$(python -c "print(${ProjData[$jnd]}*$MagMult)") 		# Set local magnitude if host RAC data is present
 			fi
-			
+
 		done
 
 	printf "${ProjWithStandForm[$project]}" >> $StatsOut 							# Add project name to table
 	LC_NUMERIC="en_US.UTF-8" printf " %0.2f" "${locMag[@]}" >> $StatsOut  			# Print host Mag with 2 decimals
-	printf "\n"  >> $StatsOut 
+	printf "\n"  >> $StatsOut
 
-	unset ProjData	
+	unset ProjData
 	unset locMag
 done
 
 # Print out table if no save location given
 if [ $# -eq 2 ]; then
 	head -n 1 $mypath/return.temp
-	tail -n +2 $mypath/return.temp | column -t -s' ' 
+	tail -n +2 $mypath/return.temp | column -t -s' '
 	rm $mypath/return.temp
 fi

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ There is an [online version](http://grcquickmag.hopto.org) with limited features
 
 
 CPU_QuickMag and GPU_QuickMag are methods for determining the approximate performance of a given CPU/GPU on all Gridcoin whitelisted projects.
-Requires: python
+Requires: python. Optional: ripgrep (for faster execution)
 
 **Steps for running code:**
 


### PR DESCRIPTION
These changes fix a significant bug in the magnitude calculation that affects all but the first project. Basically when getting the team expavg_credit, the command `grep -B 4 -A 3 ">Gridcoin<"` was matching what I assume was the intended tag `<name>Gridcoin</name>` and other tags such as `<name_html>Gridcoin</name_html>` or `<founder_name>Gridcoin</founder_name>`. This results in multiple copies of each teams' rac in TeamRac. The second project's mag is then calculated with the first team's rac, and the third and fourth projects' mags are calculated with the second team's rac, and so on.

I discovered this bug while attempting to optimize the scripts. By changing the format of the host files and tweaking various commands, I was able to improve the speed significantly. On average `UpdateDatabaseFiles.sh all` runs 70-80% faster (could be even better or worse depending on your download speed). Both CPU and GPU queries are about 55% faster, but if you install ripgrep (totally optional), it is 95% faster than the current code! On average it took me ~14s for a CPU query and ~7s for a GPU query with ripgrep. Full database update took about 10 minutes. I *still* wouldn't call this a "Quick" mag, but it's certainly better than the current multiple minutes/query.

Also as a bonus the code should now work on macOS with python. This was previously not possible because they do not come with a `tac` command, but that has been removed anyway.